### PR TITLE
Updated required_providers for clumio to support 0.4.x and 0.5.x versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ The resources can be created using `terraform apply`.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | ~>0.3.0 |
+| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.4.0, <0.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | ~>0.3.0 |
+| <a name="provider_clumio"></a> [clumio](#provider\_clumio) |  >=0.4.0, <0.6.0 |
 | <a name="provider_random"></a> [clumio](#provider\_random) | n/a |
 
 ## Modules

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     clumio = {
       source  = "clumio-code/clumio"
-      version = "~>0.4.0"
+      version = ">=0.4.0, <0.6.0"
     }
     aws = {}
     random = {}


### PR DESCRIPTION
Updated required_providers for clumio to support 0.4.x and 0.5.x versions