### PR TITLE
Allow to set an Alias and add tags to a CMK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0
+Changed the BYOK module to allow to set an Alias and tags for a CMK.
+
 ## 0.2.8
 Changed the Clumio provider version required to >=0.9.0, <0.11.0
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The resources can be created using `terraform apply`.
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 | <a name="provider_clumio"></a> [clumio](#provider\_clumio) |  >=0.8.0, <0.10.0 |
-| <a name="provider_random"></a> [clumio](#provider\_random) | n/a |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
 
@@ -66,6 +66,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_kms_key.multi_region_cmk_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_kms_key.aws_kms_alias](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [clumio_post_process_kms.clumio_phone_home](https://registry.terraform.io/providers/clumio-code/clumio/latest/docs/resources/clumio_post_process_kms) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.byok_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -82,9 +83,11 @@ No modules.
 | <a name="input_clumio_account_id"></a> [clumio\_account\_id](#input\_clumio\_account\_id) | Clumio account ID. | `string` | n/a | yes |
 | <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | Primary and replica key deletion window in days. | `number` | `30` | no |
 | <a name="input_token"></a> [token](#input\_token) | The AWS integration ID token. | `string` | n/a | yes |
-| <a name="input_role_name"></a> [token](#input\_role_name) | The name with which to create the AWS IAM role to manage the CMK. | `string` | ClumioKMSRole | no |
-| <a name="input_external_id"></a> [token](#input\_external_id) | The external ID to use when assuming the AWS IAM role. | `string` | random | no |
-| <a name="input_existing_cmk_id"></a> [token](#input\_existing_cmk_id) | The ID of an existing CMK to use as the BYOK encryption key. | `string` | n/a | no |
+| <a name="input_role_name"></a> [role_name](#input\_role_name) | The name with which to create the AWS IAM role to manage the CMK. | `string` | ClumioKMSRole | no |
+| <a name="input_external_id"></a> [external_id](#input\_external_id) | The external ID to use when assuming the AWS IAM role. | `string` | random | no |
+| <a name="input_existing_cmk_id"></a> [existing_cmk_id](#input\_existing_cmk_id) | The ID of an existing CMK to use as the BYOK encryption key. | `string` | n/a | no |
+| <a name="input_key_tags"></a> [key_tags](#input\_key_tags) | Tags for mutli-region CMK to be created. Not used if existing_cmk_id is provided. | `map(string)` | n/a | no |
+| <a name="input_key_alias_name"></a> [key_alias_name](#input\_key_alias_name) | Alias name for multi-region CMK to be used (optional). Default value is clumio-byok. | `string` | clumio-byok | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -79,6 +79,12 @@ resource "aws_kms_key" "multi_region_cmk_key" {
   enable_key_rotation      = true
   deletion_window_in_days  = var.deletion_window_in_days
   policy                   = data.aws_iam_policy_document.byok_policy_document.json
+  tags                     = var.key_tags
+}
+
+resource "aws_kms_alias" "key_alias" {
+  name = "alias/${var.key_alias_name}"
+  target_key_id = var.existing_cmk_id != "" ? var.existing_cmk_id : aws_kms_key.multi_region_cmk_key[0].id
 }
 
 resource "aws_iam_role" "byok_mgmt_role" {

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,15 @@ variable "deletion_window_in_days" {
   type = number
   default = 30
 }
+
+variable "key_tags" {
+  description = "Tags for mutli-region CMK to be created. Not used if existing_cmk_id is provided."
+  type = map(string)
+  default = {}
+}
+
+variable "key_alias_name" {
+  description = "Alias name for multi-region CMK to be used (optional)."
+  type = string
+  default = "clumio-byok"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -44,7 +44,7 @@ variable "key_tags" {
 }
 
 variable "key_alias_name" {
-  description = "Alias name for multi-region CMK to be used (optional)."
+  description = "Alias name for multi-region CMK to be used (optional). Default value is clumio-byok."
   type = string
   default = "clumio-byok"
 }


### PR DESCRIPTION
Testing:
- Install module with newly added parameters: Create alias and Add tags from user input
  ```
  ...

  # module.clumio_byok.aws_kms_alias.key_alias will be created
  + resource "aws_kms_alias" "key_alias" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/dongjoo"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.clumio_byok.aws_kms_key.multi_region_cmk_key[0] will be created
  + resource "aws_kms_key" "multi_region_cmk_key" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 30
      + description                        = "The CMK for Clumio to use to encrypt backups"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = true
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::082615160027:root"
                        }
                      + Resource  = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + rotation_period_in_days            = (known after apply)
      + tags                               = {
          + "key" = "value"
        }
      + tags_all                           = {
          + "key" = "value"
        }
    }

  ...

  Apply complete! Resources: 8 added, 0 changed, 0 destroyed.
  ```
  ![image](https://github.com/user-attachments/assets/e927fd37-fe60-492d-a484-53899b515e06)
  ![image](https://github.com/user-attachments/assets/d7cea29c-c5ee-45be-bfdf-42df05e379fb)

- Install module without added parameters: Create default alias. No tags.
  ```
  # module.clumio_byok.aws_kms_alias.key_alias will be created
  + resource "aws_kms_alias" "key_alias" {
      + arn            = (known after apply)
      + id             = (known after apply)
      + name           = "alias/clumio-byok"
      + name_prefix    = (known after apply)
      + target_key_arn = (known after apply)
      + target_key_id  = (known after apply)
    }

  # module.clumio_byok.aws_kms_key.multi_region_cmk_key[0] will be created
  + resource "aws_kms_key" "multi_region_cmk_key" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 30
      + description                        = "The CMK for Clumio to use to encrypt backups"
      + enable_key_rotation                = true
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = true
      + policy                             = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::082615160027:root"
                        }
                      + Resource  = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + rotation_period_in_days            = (known after apply)
      + tags_all                           = (known after apply)
    }
  ```
  
  ![image](https://github.com/user-attachments/assets/46a487ff-cfc5-4f10-bd49-cda6ae4cfe2f)