### PR TITLE
Update required Clumio provider version to >=0.20.0, <0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.5
+* Changed the Clumio provider version required to >=0.20.0, <0.22.0.
+
 ## 0.5.4
 * Replaced deprecated arguments: `inline_policy` on `aws_iam_role` and `aws_region` data source `name` attribute. Requires AWS provider >= 6.0.0.
 

--- a/README.md
+++ b/README.md
@@ -51,14 +51,14 @@ Once the wallet resource is created, the rest of the resources can be created us
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
-| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.19.0, <0.21.0 |
+| <a name="requirement_clumio"></a> [clumio](#requirement\_clumio) | >=0.20.0, <0.22.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
-| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | >=0.19.0, <0.21.0 |
+| <a name="provider_clumio"></a> [clumio](#provider\_clumio) | >=0.20.0, <0.22.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 | <a name="provider_time"></a> [time](#provider\_time) | n/a |
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     clumio = {
       source  = "clumio-code/clumio"
-      version = ">=0.19.0, <0.21.0"
+      version = ">=0.20.0, <0.22.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Summary:
- Updates the required Clumio provider version from `>=0.19.0, <0.21.0` to `>=0.20.0, <0.22.0`.
- Bumps the module to 0.5.5.
