### PR TITLE
Update required Clumio provider version to >=0.21.0, <0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.5.6
+* Changed the Clumio provider version required to >=0.21.0, <0.23.0.
+
 ## 0.5.5
 * Changed the Clumio provider version required to >=0.20.0, <0.22.0.
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     clumio = {
       source  = "clumio-code/clumio"
-      version = ">=0.20.0, <0.22.0"
+      version = ">=0.21.0, <0.23.0"
     }
     aws = {
       source  = "hashicorp/aws"


### PR DESCRIPTION
Bumps the required Clumio provider version to `>=0.21.0, <0.23.0` so the module can be used with provider `0.22.0`. CHANGELOG updated. No template content changes.
